### PR TITLE
Fix download series

### DIFF
--- a/novel.sh
+++ b/novel.sh
@@ -339,7 +339,7 @@ pixiv_list_novels_by_series() {
 	tmp=`invoke_rest_api pixiv "ajax/novel/series_content/${seriesid}?limit=${NOVELS_PER_PAGE}&last_order=${offset}&order_by=asc"`
 	__pixiv_parsehdr "$tmp" pixiv_error || return 1
 
-	json_get_object "$tmp" body.seriesContents __novels
+	json_get_object "$tmp" body.page.seriesContents __novels
 	return 0
 }
 


### PR DESCRIPTION
`seriesContents` in response json now is under `body.page`.

For example:
`https://www.pixiv.net/ajax/novel/series_content/1234568?limit=30&last_order=0&order_by=asc`

Response looks like

![image](https://github.com/user-attachments/assets/0a9a8937-e400-4ec7-921e-9e13fdab53a5)
